### PR TITLE
Add job posting date types

### DIFF
--- a/_layouts/job.html
+++ b/_layouts/job.html
@@ -12,7 +12,10 @@ layout: default
       Apply By: {{ page.apply_date | date: "%b %-d, %Y" }}
     </p>
     <p class="meta">
-      Start Work: {{ page.start_date | date: "%b %-d, %Y" }}
+      Start Work Term: {{ page.start_date | date: "%b %-d, %Y" }}
+    </p>
+    <p class="meta">
+      End Work Term: {{ page.end_date | date: "%b %-d, %Y" }}
     </p>
     <p class="meta">
       Location: {{ page.location }}

--- a/_layouts/job.html
+++ b/_layouts/job.html
@@ -6,7 +6,13 @@ layout: default
   <header class="post-header">
     <h1>{{ page.title }}</h1>
     <p class="meta">
-      Posted: {{ page.date | date: "%b %-d, %Y" }}
+      Posted: {{ page.post_date | date: "%b %-d, %Y" }}
+    </p>
+    <p class="meta">
+      Apply By: {{ page.apply_date | date: "%b %-d, %Y" }}
+    </p>
+    <p class="meta">
+      Start Work: {{ page.start_date | date: "%b %-d, %Y" }}
     </p>
     <p class="meta">
       Location: {{ page.location }}

--- a/_posts/jobs/2014-08-30-tata.md
+++ b/_posts/jobs/2014-08-30-tata.md
@@ -6,6 +6,7 @@ openings: 30-40
 post_date: 2014-08-30
 apply_date: 2014-08-30
 start_date: 2014-08-30
+end_date: 2014-08-30
 categories: jobs
 location: "Toronto"
 ---

--- a/_posts/jobs/2014-08-30-tata.md
+++ b/_posts/jobs/2014-08-30-tata.md
@@ -3,7 +3,9 @@ layout: job
 title:  "Tata Consultancy Services Canada"
 type:   "Full-Time"
 openings: 30-40
-date:   2014-08-30
+post_date: 2014-08-30
+apply_date: 2014-08-30
+start_date: 2014-08-30
 categories: jobs
 location: "Toronto"
 ---

--- a/jobs.html
+++ b/jobs.html
@@ -8,7 +8,7 @@ permalink: "/jobs/"
   {% for post in site.categories['jobs'] reversed %}
     <li>
       <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-      <p>Posted on: {{ post.date | date: "%b %-d, %Y" }} • Location: {{ post.location }}</p>
+      <p>Posted on: {{ post.post_date | date: "%b %-d, %Y" }} • Location: {{ post.location }}</p>
       <p>Type: {{ post.type }} • Number of Openings: {{ post.openings }}</p>
     </li>
   {% endfor %}


### PR DESCRIPTION
Added frontmatter vars:
- `post_date`: date when job was posted
- `apply_date`: deadline for applicants to apply
- `start_date`: date when the work term starts

Any more necessary? End date maybe?

Also in jobs.html, should `apply_date` and `start_date` be displayed here?
