### PR TITLE
Exclude expired posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ require 'rbconfig'
 gem 'wdm', '~> 0.1.0' if RbConfig::CONFIG['target_os'] =~ /mswin|mingw/i
 
 gem 'jekyll', require: false
+
+gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
     pygments.rb (0.6.0)
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.1.0)
+    rake (10.3.2)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -68,3 +69,4 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll
+  rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,4 @@
+desc 'Build with Jekyll'
+task :build do
+  system 'jekyll build'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -2,3 +2,8 @@ desc 'Build with Jekyll'
 task :build do
   system 'jekyll build'
 end
+
+desc 'Serve with Jekyll'
+task :serve do
+  system 'jekyll serve --watch'
+end

--- a/_plugins/exclude_expired.rb
+++ b/_plugins/exclude_expired.rb
@@ -1,0 +1,11 @@
+module ExcludeExpired
+  class Generator < Jekyll::Generator
+
+    def generate(site)
+
+
+
+    end
+
+  end
+end

--- a/_plugins/exclude_expired.rb
+++ b/_plugins/exclude_expired.rb
@@ -3,7 +3,11 @@ module ExcludeExpired
 
     def generate(site)
 
-
+      # Delete posts if their `expiry_date` in their frontmatter is today or later
+      site.posts.delete_if do |post|
+        expiry_date = post.data['expiry_date']
+        expiry_date >= Date.today if expiry_date
+      end
 
     end
 

--- a/_posts/events/2014-09-06-gamesnight.md
+++ b/_posts/events/2014-09-06-gamesnight.md
@@ -3,6 +3,7 @@ layout: post
 title:  "Games Night"
 description: "The first Games Night of the year"
 date:   2014-09-06
+expiry_date: 2014-09-07
 categories: events
 ---
 

--- a/_posts/events/2014-09-20-orbis.md
+++ b/_posts/events/2014-09-20-orbis.md
@@ -3,6 +3,7 @@ layout: post
 title:  "The 5th Annual Orbis Challenge"
 description: "Build a champion AI for a classic arcade game that can outperform and outlast your opponents"
 date:   2014-09-20
+expiry_date: 2014-09-21
 categories: events
 ---
 

--- a/_posts/events/2014-09-30-twittertalk.md
+++ b/_posts/events/2014-09-30-twittertalk.md
@@ -3,6 +3,7 @@ layout: post
 title:  "Twitter Tech Talk"
 description: "Twitter Tech Talk"
 date:   2014-09-30
+expiry_date: 2014-10-01
 categories: events
 ---
 

--- a/_posts/events/2014-10-25-smartweek.md
+++ b/_posts/events/2014-10-25-smartweek.md
@@ -3,6 +3,7 @@ layout: post
 title:  "SmartWeek 2014"
 description: "An industry focused IoT conference being held right here at UofT"
 date:   2014-10-25
+expiry_date: 2014-10-26
 categories: events
 ---
 

--- a/_posts/jobs/2014-08-30-tata.md
+++ b/_posts/jobs/2014-08-30-tata.md
@@ -7,6 +7,7 @@ post_date: 2014-08-30
 apply_date: 2014-08-30
 start_date: 2014-08-30
 end_date: 2014-08-30
+expiry_date: 2014-08-30
 categories: jobs
 location: "Mississauga"
 ---


### PR DESCRIPTION
Upon running `jekyll build` or `jekyll serve`, posts with an `expiry_date` past (or equal to) the current date will be excluded.
