### PR TITLE
Add embedded Google calendar

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -73,9 +73,7 @@
 </footer>
 
 <script src="http://maps.google.com/maps/api/js?sensor=false"></script>
-
 <script src="/js/script.min.js"></script>
-
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/calendar.html
+++ b/calendar.html
@@ -1,0 +1,8 @@
+---
+layout: page
+title: Calendar
+permalink: "/calendar/"
+---
+
+<iframe class="responsive-iframe"
+        src="https://www.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showPrint=0&amp;showCalendars=0&amp;mode=WEEK&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=cp18p9i0hpoa8l646468i8q45s%40group.calendar.google.com&amp;color=%230F4B38&amp;ctz=America%2FToronto"></iframe>

--- a/calendar.html
+++ b/calendar.html
@@ -1,8 +1,0 @@
----
-layout: page
-title: Calendar
-permalink: "/calendar/"
----
-
-<iframe class="responsive-iframe"
-        src="https://www.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showPrint=0&amp;showCalendars=0&amp;mode=WEEK&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=cp18p9i0hpoa8l646468i8q45s%40group.calendar.google.com&amp;color=%230F4B38&amp;ctz=America%2FToronto"></iframe>

--- a/css/main.scss
+++ b/css/main.scss
@@ -306,6 +306,12 @@ th, tr:nth-child(even) {
   }
 }
 
+.responsive-iframe {
+  border-width: 0;
+  width: 100%;
+  height: 600px;
+}
+
 
 /* Home styles */
 /* ----------------------------------------------------------*/

--- a/events.html
+++ b/events.html
@@ -4,6 +4,9 @@ title: Events
 permalink: "/events/"
 ---
 
+<iframe class="responsive-iframe"
+        src="https://www.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showPrint=0&amp;showCalendars=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=cp18p9i0hpoa8l646468i8q45s%40group.calendar.google.com&amp;color=%230F4B38&amp;ctz=America%2FToronto"></iframe>
+
 <ul class="posts page-list">
   {% for post in site.categories['events'] reversed %}
     <li>


### PR DESCRIPTION
![screenshot 2014-09-29 14 55 26](https://cloud.githubusercontent.com/assets/2177366/4447364/376d9808-480a-11e4-9daa-7d5a3241b51a.png)

Will need to add a link from the home page. Should this be integrated with the events page somehow?
