### PR TITLE
Fix UofT logo, tone down SCSS nesting

### DIFF
--- a/_assets/stylesheets/main.css.scss
+++ b/_assets/stylesheets/main.css.scss
@@ -106,27 +106,27 @@ th, tr:nth-child(even) {
 
 .site-nav {
   margin-top: 2em;
-}
 
-.site-nav .menu-icon { display: none; }
+  .menu-icon { display: none; }
 
-.site-nav .page-link {
-  border-bottom: 1px solid transparent;
-  color: #fff;
-  font-size: 1.25em;
-  font-weight: 300;
-  margin-right: 20px;
-  padding: 0.25em 0;
-  transition: border-color 0.3s;
+  .page-link {
+    border-bottom: 1px solid transparent;
+    color: #fff;
+    font-size: 1.25em;
+    font-weight: 300;
+    margin-right: 20px;
+    padding: 0.25em 0;
+    transition: border-color 0.3s;
 
-  &:hover {
-    border-color: #fff;
-    text-decoration: none;
+    &:hover {
+      border-color: #fff;
+      text-decoration: none;
+    }
   }
-}
 
-.site-nav .current {
-  border-color: #fff;
+  .current {
+    border-color: #fff;
+  }
 }
 
 
@@ -174,6 +174,7 @@ th, tr:nth-child(even) {
       opacity: 1;
     }
   }
+}
 
   .footer-heading {
     font: 300 2.5em 'Nexa Light';
@@ -255,7 +256,7 @@ th, tr:nth-child(even) {
   }
 
   .footer-uoft a {
-    background-size: 275px 18px;
+    background-size: 275px 18px !important;
     background: transparent image-url('uoft.png') no-repeat;
     display: block;
     height: 18px;
@@ -269,7 +270,6 @@ th, tr:nth-child(even) {
       text-decoration: none;
     }
   }
-}
 
 .footer-map {
   height: 100%;
@@ -374,6 +374,7 @@ th, tr:nth-child(even) {
   display: table;
   padding-top: 1.5em;
   width: 100%;
+}
 
   #home-row-inner {
     display: table-row;
@@ -432,7 +433,6 @@ th, tr:nth-child(even) {
 
     a { color: $grey; }
   }
-}
 
 .posts {
   list-style-type: none;
@@ -481,12 +481,12 @@ ul.members-list {
       width: 5.5em;
       margin: 0 auto 0.5em;
     }
-
-    .member-name { font-weight: 600; }
-
-    .member-role { font-weight: 300; }
   }
 }
+
+  .member-name { font-weight: 600; }
+
+  .member-role { font-weight: 300; }
 
 #home-members {
   margin-top: 30px;
@@ -495,6 +495,7 @@ ul.members-list {
   & > a:hover {
     text-decoration: none;
   }
+}
 
   .members {
     background-color: #e1e1e1;
@@ -513,7 +514,6 @@ ul.members-list {
       min-width: 10em;
     }
   }
-}
 
 .members-page {
   text-align: center;
@@ -872,7 +872,7 @@ ul.members-list {
 
 }
 
-@media screen and (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
 
   .side-header .wrap {
     background-image: image-url('logo@2x.png') !important;


### PR DESCRIPTION
This fixes the issue with the UofT logo on higher DPI displays noted in https://github.com/cssu/cssu.ca/pull/28#issuecomment-70380671

This also includes some work on un-nesting some selectors in the SCSS, to keep specificity down.
