### PR TITLE
Fix Travis deployment

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -19,15 +19,28 @@ eval "$(ssh-agent -s)"
 chmod 600 .travis/deploy_key
 ssh-add .travis/deploy_key
 
-# Copy the static site to CS Teaching Labs, preserving the gallery and wiki directories
+# Copy the static site to the a temporary location on CS Teaching Labs dbsrv1 server
 echo "Copying static site to dbsrv1.teach.cs.toronto.edu:/data/www/cssu/htdocs via rsync..."
 rsync \
   --archive \
   --compress \
   --delete \
-  --exclude="/data/" \
-  --exclude="/gallery/" \
-  --exclude="/w/" \
   --verbose \
   _site/ \
-  cssuwww@dbsrv1.teach.cs.toronto.edu:/data/www/cssu/htdocs
+  cssuwww@dbsrv1.teach.cs.toronto.edu:/u/cssuwww/tmpsite
+
+# Copy the files from dbsrv1 to earth (since earth is only accessible from within the CS Teaching Labs network),
+# preserving the gallery and wiki directories
+ssh cssuwww@dbsrv1.teach.cs.toronto.edu /bin/bash << EOF
+  cd /u/cssuwww/tmpsite
+  rsync \
+    --archive \
+    --compress \
+    --delete \
+    --exclude="/data/" \
+    --exclude="/gallery/" \
+    --exclude="/w/" \
+    --verbose \
+    . \
+    cssuwww@earth.teach.cs.toronto.edu:/data/www/cssu/htdocs
+EOF


### PR DESCRIPTION
The cssu.ca website files have moved from `dbsrv1.teach.cs.toronto.edu` to `earth.teach.cs.toronto.edu`. Unfortunately, `earth` isn't accessible from outside the CS Teaching Labs network, so I'm indirectly copying files to `dbsrv1` first, then copying it from there to `earth` after SSH-ing in.

Tested locally with a modified script using my own account:
```bash
# Copy the static site to the a temporary location on CS Teaching Labs dbsrv1 server
echo "Copying static site to dbsrv1.teach.cs.toronto.edu:/data/www/cssu/htdocs via rsync..."
rsync \
  --archive \
  --compress \
  --delete \
  --verbose \
  _site/ \
  cheun550@dbsrv1.teach.cs.toronto.edu:/h/u10/g3/00/cheun550/tmpsite

# Copy the files from dbsrv1 to earth (since earth is only accessible from within the CS Teaching Labs network),
# preserving the gallery and wiki directories
ssh cheun550@dbsrv1.teach.cs.toronto.edu /bin/bash << EOF
  cd /h/u10/g3/00/cheun550/tmpsite
  rsync \
    --archive \
    --compress \
    --delete \
    --exclude="/data/" \
    --exclude="/gallery/" \
    --exclude="/w/" \
    --verbose \
    . \
    cheun550@earth.teach.cs.toronto.edu:/h/u10/g3/00/cheun550/tmpsite2
EOF
```