### PR TITLE
Format calendar event times, remove commented out code

### DIFF
--- a/_assets/javascripts/calendar.js
+++ b/_assets/javascripts/calendar.js
@@ -55,8 +55,8 @@ function appendTimeEvent(event) {
   var endTime = new Date(event.end.dateTime);
   var eventEl = _createEventEl(startTime, event.summary, event.description, event.location);
   eventEl.appendChild(_createElement('p', null,
-      'From ' + startTime.toLocaleTimeString('en-US') +
-      ' to ' + endTime.toLocaleTimeString('en-US')));
+      'From ' + _formatTime(startTime) +
+      ' to ' + _formatTime(endTime)));
   eventsListEl.appendChild(eventEl);
 }
 
@@ -76,7 +76,7 @@ function _createEventEl(date, summary, description, location) {
   var eventEl = _createElement('li');
 
   var eventDateEl = _createElement('div', {'class': 'event-date'});
-  eventDateEl.appendChild(_createElement('p', {'class': 'event-month'}, date.toLocaleString('en-US', {month: 'short'})));
+  eventDateEl.appendChild(_createElement('p', {'class': 'event-month'}, _formatMonth(date)));
   eventDateEl.appendChild(_createElement('p', {'class': 'event-day'}, date.getUTCDate()));
   eventEl.appendChild(eventDateEl);
 
@@ -111,4 +111,18 @@ function _createElement(type, attrs, text) {
   }
 
   return el;
+}
+
+/**
+ * Formats a date object's time value as "h:mm tt".
+ */
+function _formatTime(date) {
+  return date.toLocaleTimeString('en-us', { hour: '2-digit', minute: '2-digit' });
+}
+
+/**
+ * Formats a date object's month value as "MMM".
+ */
+function _formatMonth(date) {
+  return date.toLocaleString('en-us', { month: 'short' })
 }

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -38,13 +38,6 @@
           <a class="page-link {{ current }}" href="{{ link.url }}">{{ link.title }}</a>
           {% endif %}
         {% endfor %}
-
-        <!-- <a class="page-link drop" href="cssu.ca">Head2 ▾</a>
-          <ul class="nav-dropdown">
-              <li><a class="page-link " href="#!">Web</a></li>
-              <li><a class="page-link " href="#!">Web</a></li>
-              <li><a class="page-link " href="#!">Graphic2 Design2</a></li>
-          </ul> -->
       </div>
     </nav>
   </div>


### PR DESCRIPTION
- Formatting Google Calendar event times in a format like "9:00 PM" (i.e. no seconds)
- Remove test code